### PR TITLE
EPOP: Make the epop for minigame broadcast blocking

### DIFF
--- a/lua/minigames/engine/sh_functions.lua
+++ b/lua/minigames/engine/sh_functions.lua
@@ -16,7 +16,8 @@ function ActivateMinigame(minigame)
 				color = COLOR_ORANGE
 			},
 			minigame.lang.desc and LANG.TryTranslation("ttt2_minigames_" .. minigame.name .. "_desc") or nil,
-			12
+			12,
+			true
 		)
 	end
 


### PR DESCRIPTION
I made the popup for the initial broadcast of the starting minigame blocking, so that no other epop message can overwrite it.