### PR TITLE
Improvement: Minigame call order, fixed active state, added possibility to modify the EPOP

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Here is an easy example of a `Minigame`: [Hardcore Minigame](https://github.com/
 #### Hooks (**`shared`**)
 Hook | Utilization
 --- | ---
+`MINIGAME:PreInitialize()` | Called before the `Minigame`'s data is loaded
+`MINIGAME:SetupData()` | Called as soon as the default data has been loaded and the `Minigame` has be pre-initialized
+`MINIGAME:Initialize()` | Is automatically called as soon as the `Minigame` data has been loaded
 `MINIGAME:OnActivation()` | Called if the `Minigame` is activated
 `MINIGAME:OnDeactivation()` | Called if the `Minigame` is deactivated
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Hook | Utilization
 `TTT2MGPreDeactivate(minigame)`| Called right before the `Minigame` deactivates
 `TTT2MGDeactivate(minigame)` | Called if the `Minigame` deactivates
 `TTT2MGPostDeactivate(minigame)` | Called after the `Minigame` was deactivated
+`TTT2MinigamesLoaded()` | Called as soon as every `MINIGAME` was loaded
 
 ### Multilanguage support
 Here is an example how to add language support to your `Minigame`:

--- a/README.md
+++ b/README.md
@@ -54,46 +54,47 @@ Here is an easy example of a `Minigame`: [Hardcore Minigame](https://github.com/
 #### Hooks (**`shared`**)
 Hook | Utilization
 --- | ---
-`MINIGAME:OnActivation` | Called if the `Minigame` is activated
-`MINIGAME:OnDeactivation` | Called if the `Minigame` is deactivated
+`MINIGAME:OnActivation()` | Called if the `Minigame` is activated
+`MINIGAME:OnDeactivation()` | Called if the `Minigame` is deactivated
 
 #### Functions
 Function | Utilization | Realm
 --- | --- | ---
-`MINIGAME:Activate` | Activates the `Minigame`. By default, this is done autimatically (internally) | `shared`
-`MINIGAME:Deactivate` | Deactivates the `Minigame`. By default, this is done autimatically (internally) | `shared`
-`MINIGAME:IsActive` | Returns whether the `Minigame` is active | `shared`
-`MINIGAME:IsSelectable` | Returns whether the `Minigame` is selectable (and take place in the `minigame`s selection) | `server`
+`MINIGAME:Activate()` | Activates the `Minigame`. By default, this is done autimatically (internally) | `shared`
+`MINIGAME:Deactivate()` | Deactivates the `Minigame`. By default, this is done autimatically (internally) | `shared`
+`MINIGAME:IsActive()` | Returns whether the `Minigame` is active | `shared`
+`MINIGAME:IsSelectable()` | Returns whether the `Minigame` is selectable (and take place in the `minigame`s selection) | `server`
+`MINIGAME:ShowActivationEPOP()` | Should be used to display a EPOP message informing the player about the `Minigame` activation (automatically called as soon as the `Minigame` is activated) | `client`
 
 ### `minigames` module
 #### Functions
 Function | Utilization | Realm
 --- | --- | ---
-`minigames.IsBasedOn` | Checks if name is based on base | `shared`
-`minigames.GetStored` | Gets the real `Minigame` table (not a copy) | `shared`
-`minigames.GetList` | Get a list (copy) of all registered `Minigame`s, that can be displayed (no abstract `Minigame`s) | `shared`
-`minigames.GetRealList`| Get an indexed list of all the registered `Minigame`s including abstract `Minigame`s | `shared`
-`minigames.GetActiveList`| Returns a list of active `Minigame`s | `shared`
-`minigames.GetById` | Get the `Minigame` table by the `Minigame` id | `shared`
-`minigames.ForceNextMinigame` | Forces the next `Minigame` | `server`
-`minigames.GetForcedNextMinigame`| Returns the next forced `Minigame` | `server`
-`minigames.Select`| Selects a `Minigame` based on the current available `Minigame`s | `server`
+`minigames.IsBasedOn(name, base)` | Checks if name is based on base | `shared`
+`minigames.GetStored(name)` | Gets the real `Minigame` table (not a copy) | `shared`
+`minigames.GetList()` | Get a list (copy) of all registered `Minigame`s, that can be displayed (no abstract `Minigame`s) | `shared`
+`minigames.GetRealList()`| Get an indexed list of all the registered `Minigame`s including abstract `Minigame`s | `shared`
+`minigames.GetActiveList()`| Returns a list of active `Minigame`s | `shared`
+`minigames.GetById(id)` | Get the `Minigame` table by the `Minigame` id | `shared`
+`minigames.ForceNextMinigame(minigame)` | Forces the next `Minigame` | `server`
+`minigames.GetForcedNextMinigame()`| Returns the next forced `Minigame` | `server`
+`minigames.Select()`| Selects a `Minigame` based on the current available `Minigame`s | `server`
 
 ### global functions (**`shared`**)
 Function | Utilization
 --- | ---
-`ActivateMinigame` | Activates a `Minigame`. If called on `server`, the sync with the `client`s will be run. If called on `client`, a popup will be displayed for 12 seconds
-`DeactivateMinigame` | Deactivates a `Minigame`. If called on `server`, the sync with the `client`s will be run.
+`ActivateMinigame(minigame)` | Activates a `Minigame`. If called on `server`, the sync with the `client`s will be run. If called on `client`, a popup will be displayed for 12 seconds
+`DeactivateMinigame(minigame)` | Deactivates a `Minigame`. If called on `server`, the sync with the `client`s will be run.
 
 ### `GAMEMODE` hooks (**`shared`**)
 Hook | Utilization
 --- | ---
-`TTT2MGPreActivate`| Called right before the `Minigame` activates
-`TTT2MGActivate` | Called if the `Minigame` activates
-`TTT2MGPostActivate` | Called after the `Minigame` was activated
-`TTT2MGPreDeactivate`| Called right before the `Minigame` deactivates
-`TTT2MGDeactivate` | Called if the `Minigame` deactivates
-`TTT2MGPostDeactivate` | Called after the `Minigame` was deactivated
+`TTT2MGPreActivate(minigame)`| Called right before the `Minigame` activates
+`TTT2MGActivate(minigame)` | Called if the `Minigame` activates
+`TTT2MGPostActivate(minigame)` | Called after the `Minigame` was activated
+`TTT2MGPreDeactivate(minigame)`| Called right before the `Minigame` deactivates
+`TTT2MGDeactivate(minigame)` | Called if the `Minigame` deactivates
+`TTT2MGPostDeactivate(minigame)` | Called after the `Minigame` was deactivated
 
 ### Multilanguage support
 Here is an example how to add language support to your `Minigame`:

--- a/lua/includes/modules/minigames.lua
+++ b/lua/includes/modules/minigames.lua
@@ -89,11 +89,13 @@ local function SetupData(minigame)
 
 	---
 	-- @name ttt2_minigames_[MINIGAME]_enabled
-	CreateConVar("ttt2_minigames_" .. minigame.name .. "_enabled", "1", {FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED})
+	CreateConVar("ttt2_minigames_" .. minigame.name .. "_enabled", "1", {FCVAR_NOTIFY, FCVAR_ARCHIVE})
 
 	---
 	-- @name ttt2_minigames_[MINIGAME]_random
-	CreateConVar("ttt2_minigames_" .. minigame.name .. "_random", "100", {FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED})
+	CreateConVar("ttt2_minigames_" .. minigame.name .. "_random", "100", {FCVAR_NOTIFY, FCVAR_ARCHIVE})
+
+	minigame:SetupData()
 end
 
 ---
@@ -112,12 +114,23 @@ function minigames.OnLoaded()
 		MGList[k] = newTable
 
 		baseclass.Set(k, newTable)
+
+		if not newTable.isAbstract then
+			newTable:PreInitialize()
+		end
 	end
 
-	-- Setup data (eg. convars for all minigames)
+	-- Setup data (eg. convars for all @{MINIGAME}s)
 	for _, v in pairs(MGList) do
 		if not v.isAbstract then
 			SetupData(v)
+		end
+	end
+
+	-- Call Initialize() on all @{MINIGAME}s
+	for _, v in pairs(MGList) do
+		if not v.isAbstract then
+			v:Initialize()
 		end
 	end
 end
@@ -130,17 +143,19 @@ end
 -- @realm shared
 -- @internal
 function minigames.Get(name, retTbl)
-	local Stored = minigames.GetStored(name)
-	if not Stored then return end
+	local stored = minigames.GetStored(name)
+	if not stored then return end
 
 	-- Create/copy a new table
 	local retval = retTbl or {}
 
-	for k, v in pairs(Stored) do
-		if istable(v) then
-			retval[k] = table.Copy(v)
-		else
-			retval[k] = v
+	if retTbl ~= stored then
+		for k, v in pairs(stored) do
+			if istable(v) then
+				retval[k] = table.Copy(v)
+			else
+				retval[k] = v
+			end
 		end
 	end
 

--- a/lua/includes/modules/minigames.lua
+++ b/lua/includes/modules/minigames.lua
@@ -133,6 +133,8 @@ function minigames.OnLoaded()
 			v:Initialize()
 		end
 	end
+
+	hook.Run("TTT2MinigamesLoaded")
 end
 
 ---

--- a/lua/minigames/engine/sh_convars.lua
+++ b/lua/minigames/engine/sh_convars.lua
@@ -54,7 +54,7 @@ if SERVER then
 	local ttt2_minigames_autostart_rounds = CreateConVar("ttt2_minigames_autostart_rounds", "0", {FCVAR_NOTIFY, FCVAR_ARCHIVE})
 
 	-- ConVar Replicating
-	hook.Add("TTTUlxInitCustomCVar", "TTT2MGInitRWCVar", function()
+	hook.Add("TTT2MinigamesLoaded", "TTT2MGInitRWCVar", function()
 		ULib.replicatedWritableCvar(ttt2_minigames:GetName(), "rep_" .. ttt2_minigames:GetName(), ttt2_minigames:GetBool(), true, true, "xgui_gmsettings")
 		ULib.replicatedWritableCvar(ttt2_minigames_autostart_random:GetName(), "rep_" .. ttt2_minigames_autostart_random:GetName(), ttt2_minigames_autostart_random:GetFloat(), true, true, "xgui_gmsettings")
 		ULib.replicatedWritableCvar(ttt2_minigames_autostart_rounds:GetName(), "rep_" .. ttt2_minigames_autostart_rounds:GetName(), ttt2_minigames_autostart_rounds:GetInt(), true, true, "xgui_gmsettings")
@@ -202,13 +202,13 @@ else
 			for name, data in pairs(cvd) do
 				if data.checkbox then
 					lst:AddItem(xlib.makecheckbox{
-						label = name .. ": " .. (data.desc or ""),
+						label = data.desc or name,
 						repconvar = "rep_" .. name,
 						parent = lst
 					})
 				elseif data.slider then
 					lst:AddItem(xlib.makeslider{
-						label = name .. ": " .. (data.desc or ""),
+						label = data.desc or name,
 						min = data.min or 1,
 						max = data.max or 1000,
 						decimal = data.decimal or 0,
@@ -216,12 +216,10 @@ else
 						parent = lst
 					})
 				elseif data.combobox then
-					if data.desc then
-						lst:AddItem(xlib.makelabel{
-							label = name .. ": " .. (data.desc or ""),
-							parent = lst
-						})
-					end
+					lst:AddItem(xlib.makelabel{
+						label = data.desc or name,
+						parent = lst
+					})
 
 					lst:AddItem(xlib.makecombobox{
 						enableinput = data.enableinput or false,

--- a/lua/minigames/engine/sh_convars.lua
+++ b/lua/minigames/engine/sh_convars.lua
@@ -1,3 +1,26 @@
+local function GetConVarData(minigame)
+	local cvd = minigame.conVarData or {}
+
+	local name = "ttt2_minigames_" .. minigame.name .. "_enabled"
+
+	cvd[name] = cvd[name] or {
+		checkbox = true,
+		desc = "Enabled? (def. 1)"
+	}
+
+	name = "ttt2_minigames_" .. minigame.name .. "_random"
+
+	cvd[name] = cvd[name] or {
+		slider = true,
+		min = 0,
+		max = 100,
+		decimal = 0,
+		desc = "Random Chance: (def. 100)"
+	}
+
+	return cvd
+end
+
 if SERVER then
 	local function AutoReplicateConVar(name, data)
 		local cv = GetConVar(name)
@@ -41,9 +64,7 @@ if SERVER then
 
 		for i = 1, #mgs do
 			local mg = mgs[i]
-			local cvd = mg.conVarData
-
-			if not istable(cvd) or table.Count(cvd) < 1 then continue end
+			local cvd = GetConVarData(mg)
 
 			for name, data in pairs(cvd) do
 				AutoReplicateConVar(name, data)
@@ -57,13 +78,13 @@ else
 		local pnl = xlib.makelistlayout{w = 415, h = 318, parent = xgui.null}
 
 		local clp = vgui.Create("DCollapsibleCategory", pnl)
-		clp:SetSize(390, 150)
+		clp:SetSize(390, 200)
 		clp:SetExpanded(1)
 		clp:SetLabel("Basic Settings")
 
 		local lst = vgui.Create("DPanelList", clp)
 		lst:SetPos(5, 25)
-		lst:SetSize(390, 150)
+		lst:SetSize(390, 250)
 		lst:SetSpacing(5)
 
 		lst:AddItem(xlib.makelabel{
@@ -100,11 +121,11 @@ else
 		})
 
 		lst:AddItem(xlib.makeslider{
-			label = "TTT2 Minigames autostart rounds? (ttt2_minigames_autostart_rounds) (Def. 0)",
+			label = "ttt2_minigames_autostart_rounds (Def. 0)",
 			min = 0,
 			max = 100,
 			decimal = 0,
-			repconvar = "ttt2_minigames_autostart_rounds",
+			repconvar = "rep_ttt2_minigames_autostart_rounds",
 			parent = lst
 		})
 
@@ -127,11 +148,11 @@ else
 		})
 
 		lst:AddItem(xlib.makeslider{
-			label = "TTT2 Minigames autostart randomness? (ttt2_minigames_autostart_random) (Def. 100)",
+			label = "ttt2_minigames_autostart_random (Def. 100)",
 			min = 0,
 			max = 100,
 			decimal = 0,
-			repconvar = "ttt2_minigames_autostart_random",
+			repconvar = "rep_ttt2_minigames_autostart_random",
 			parent = lst
 		})
 
@@ -141,10 +162,7 @@ else
 
 		for i = 1, #mgs do
 			local mg = mgs[i]
-			local cvd = mg.conVarData
-
-			if not istable(cvd) or table.Count(cvd) < 1 then continue end
-
+			local cvd = GetConVarData(mg)
 			local size = 0
 
 			for _, data in pairs(cvd) do

--- a/lua/minigames/engine/sh_functions.lua
+++ b/lua/minigames/engine/sh_functions.lua
@@ -10,15 +10,6 @@ function ActivateMinigame(minigame)
 		net.Start("TTT2MGActivateMinigame")
 		net.WriteUInt(minigame.id, MINIGAMES_BITS)
 		net.Broadcast()
-	elseif GetConVar("ttt2_minigames_show_popup"):GetBool() and istable(minigame.lang) then -- show popup if a minigame is activated
-		EPOP:AddMessage({
-				text = LANG.TryTranslation("ttt2_minigames_" .. minigame.name .. "_name"),
-				color = COLOR_ORANGE
-			},
-			minigame.lang.desc and LANG.TryTranslation("ttt2_minigames_" .. minigame.name .. "_desc") or nil,
-			12,
-			true
-		)
 	end
 
 	hook.Run("TTT2MGActivate", minigame)

--- a/lua/minigames/minigames/minigame_base/shared.lua
+++ b/lua/minigames/minigames/minigame_base/shared.lua
@@ -51,6 +51,7 @@ end
 
 ---
 -- Returns whether the current @{MINIGAME} is active
+-- @return bool
 -- @realm shared
 function MINIGAME:IsActive()
 	return self.m_bActive

--- a/lua/minigames/minigames/minigame_base/shared.lua
+++ b/lua/minigames/minigames/minigame_base/shared.lua
@@ -5,9 +5,9 @@
 MINIGAME.author = "" -- author
 MINIGAME.contact = "" -- contact to the author
 
-MINIGAME.isAbstract = true -- abstract MINIGAME you can derive from 
+MINIGAME.isAbstract = true -- abstract MINIGAME you can derive from
 
-local active = false
+MINIGAME.m_bActive = false
 
 ---
 -- Activates the @{MINIGAME}
@@ -15,11 +15,16 @@ local active = false
 function MINIGAME:Activate()
 	self:OnActivation()
 
-	active = true
+	self.m_bActive = true
+
+	if CLIENT and GetConVar("ttt2_minigames_show_popup"):GetBool() then -- show popup if the @{MINIGAME} is activated
+		self:ShowActivationEPOP()
+	end
 end
 
 ---
 -- Called if the @{MINIGAME} activates
+-- @note At the time of the call, the @{MINIGAME} does not yet return `true` with @{MINIGAME:IsActive()}
 -- @hook
 -- @realm shared
 function MINIGAME:OnActivation()
@@ -32,11 +37,12 @@ end
 function MINIGAME:Deactivate()
 	self:OnDeactivation()
 
-	active = false
+	self.m_bActive = false
 end
 
 ---
 -- Called if the @{MINIGAME} deactivates
+-- @note At the time of the call, the @{MINIGAME} does not yet return `false` with @{MINIGAME:IsActive()}
 -- @hook
 -- @realm shared
 function MINIGAME:OnDeactivation()
@@ -44,10 +50,10 @@ function MINIGAME:OnDeactivation()
 end
 
 ---
--- Returns whether the current minigame is active
+-- Returns whether the current @{MINIGAME} is active
 -- @realm shared
 function MINIGAME:IsActive()
-	return active
+	return self.m_bActive
 end
 
 if SERVER then
@@ -57,5 +63,21 @@ if SERVER then
 	-- @realm server
 	function MINIGAME:IsSelectable()
 		return true
+	end
+else
+	---
+	-- This function is called as soon as the @{MINIGAME} is activated and should be used to display a EPOP message informing the player about the activation
+	-- @realm client
+	function MINIGAME:ShowActivationEPOP()
+		if not istable(self.lang) or not EPOP then return end
+
+		EPOP:AddMessage({
+				text = LANG.TryTranslation("ttt2_minigames_" .. self.name .. "_name"),
+				color = COLOR_ORANGE
+			},
+			self.lang.desc and LANG.TryTranslation("ttt2_minigames_" .. self.name .. "_desc") or nil,
+			12,
+			true
+		)
 	end
 end

--- a/lua/minigames/minigames/minigame_base/shared.lua
+++ b/lua/minigames/minigames/minigame_base/shared.lua
@@ -23,7 +23,7 @@ end
 
 ---
 -- Initializes the @{MINIGAME}
--- @note Is automatically called as soon as the minigame data has been loaded
+-- @note Is automatically called as soon as the @{MINIGAME} data has been loaded
 -- @realm shared
 function MINIGAME:Initialize()
 

--- a/lua/minigames/minigames/minigame_base/shared.lua
+++ b/lua/minigames/minigames/minigame_base/shared.lua
@@ -7,7 +7,27 @@ MINIGAME.contact = "" -- contact to the author
 
 MINIGAME.isAbstract = true -- abstract MINIGAME you can derive from
 
-MINIGAME.m_bActive = false
+---
+-- Called before the @{MINIGAME}'s data is loaded
+-- @realm shared
+function MINIGAME:PreInitialize()
+
+end
+
+---
+-- Called as soon as the default data has been loaded and the @{MINIGAME} has be pre-initialized
+-- @realm shared
+function MINIGAME:SetupData()
+
+end
+
+---
+-- Initializes the @{MINIGAME}
+-- @note Is automatically called as soon as the minigame data has been loaded
+-- @realm shared
+function MINIGAME:Initialize()
+
+end
 
 ---
 -- Activates the @{MINIGAME}
@@ -37,7 +57,7 @@ end
 function MINIGAME:Deactivate()
 	self:OnDeactivation()
 
-	self.m_bActive = false
+	self.m_bActive = nil
 end
 
 ---
@@ -54,7 +74,7 @@ end
 -- @return bool
 -- @realm shared
 function MINIGAME:IsActive()
-	return self.m_bActive
+	return self.m_bActive == true
 end
 
 if SERVER then
@@ -77,8 +97,7 @@ else
 				color = COLOR_ORANGE
 			},
 			self.lang.desc and LANG.TryTranslation("ttt2_minigames_" .. self.name .. "_desc") or nil,
-			12,
-			true
+			12
 		)
 	end
 end

--- a/lua/minigames/minigames/minigame_base/shared.lua
+++ b/lua/minigames/minigames/minigame_base/shared.lua
@@ -97,7 +97,9 @@ else
 				color = COLOR_ORANGE
 			},
 			self.lang.desc and LANG.TryTranslation("ttt2_minigames_" .. self.name .. "_desc") or nil,
-			12
+			12,
+			nil,
+			true
 		)
 	end
 end


### PR DESCRIPTION
- Added `MINIGAME:ShowActivationEPOP()` as a possibility to overwrite the EPOP with an own version
- Fixed `active` state
- Improved the `minigame`'s call order
  - Added `MINIGAME:PreInitialize()`
  - Added `MINIGAME:SetupData()`
  - Added `MINIGAME:Initialize()`
- Fixed EPOP bug reasoned by #5 
- Fixed incorrect ConVar replication (ULX) for `ttt2_minigames_autostart_rounds` and `rep_ttt2_minigames_autostart_random` ConVar
- Expanded the size of basic settings to allow for all ConVars to be visible
- Simplified a few labels to fix graphical bugs
- Added minigame enabled and minigame random chance ConVars to ULX menu
- Fixed wrong ConVar replication (ULX) order
- Added `TTT2MinigamesLoaded` hook